### PR TITLE
Extended test-mode does not work with Match, unless you specify each…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -166,7 +166,7 @@
     mode: 0600
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
-    validate: "/usr/sbin/sshd -T -f %s"
+    validate: "/usr/sbin/sshd -t -f %s"
   notify: restart sshd
   tags:
     - configuration


### PR DESCRIPTION
… Match for the test using -C. Therefore this module will not work if you specify eny Matches. Thats why I changed it to use normal test-mode.

At least on Ubuntu 19.04