### PR TITLE
Version 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.3
+
+### Fixed
+
+- Fixed the problem by removing the options `GSSAPIAuthentication` and `GSSAPICleanupCredentials` if not used from the config.
+- Fixed Forgotten default vars added to the variables.
+
 ## 2.2.2
 
 ### Fixed

--- a/templates/opensshd.conf.j2
+++ b/templates/opensshd.conf.j2
@@ -130,9 +130,11 @@ KerberosTicketCleanup yes
 #KerberosGetAFSToken no
 {% endif %}
 
+{% if ssh_gssapi_support %}
 # Only enable GSSAPI authentication if it is configured.
-GSSAPIAuthentication {{ 'yes' if ssh_gssapi_support else 'no' }}
+GSSAPIAuthentication yes
 GSSAPICleanupCredentials yes
+{% endif %}
 
 # In case you don't use PAM (`UsePAM no`), you can alternatively restrict users and groups here. For key-based authentication this is not necessary, since all keys must be explicitely enabled.
 {% if ssh_deny_users -%}

--- a/vars/Oracle Linux-8.yml
+++ b/vars/Oracle Linux-8.yml
@@ -4,6 +4,7 @@
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+sshd_sftp_subsystem: "sftp internal-sftp -l INFO -f LOCAL6"
 ssh_selinux_dependency_packages:
   - policycoreutils-python-utils
   - checkpolicy

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -4,6 +4,7 @@
 sshd_service_name: sshd
 ssh_owner: root
 ssh_group: root
+sshd_sftp_subsystem: "sftp internal-sftp -l INFO -f LOCAL6"
 ssh_selinux_dependency_packages:
   - policycoreutils-python-utils
   - checkpolicy

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -5,6 +5,7 @@ sshd_service_name: ssh
 sshd_config_path: /etc/ssh
 ssh_owner: root
 ssh_group: root
+sshd_sftp_subsystem: "sftp internal-sftp -l INFO -f LOCAL6"
 ssh_selinux_dependency_packages:
   - policycoreutils
   - checkpolicy


### PR DESCRIPTION
### Fixed

- Fixed the problem by removing the options `GSSAPIAuthentication` and `GSSAPICleanupCredentials` if not used from the config.
- Fixed Forgotten default vars added to the variables.
